### PR TITLE
Explanation visualisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-PyArg is a Python-based package for computational argumentation. 
-All documentation is available at https://daphneodekerken.github.io/PyArg/.
+This branch serves as the central place to store all the scripts we used in COMMA 2024 Demonstration
+
+### Local Set-up
+
+We recommend you use `conda` ([Conda Installation](https://docs.anaconda.com/free/miniconda/index.html)) to help manage all packages
+
+You first need to clone the repo and switch to `explanation_visualisation` branch
+```
+git clone https://github.com/DaphneOdekerken/PyArg
+cd pyarg
+git checkout explanation_visualisation
+```
+
+Within the `pyarg` folder, you can run the following scripts to set up the environment
+```
+conda create -n pyarg python=3.11
+conda activate pyarg
+pip install -r requirement.txt
+pip install -e .
+python wsgi.py
+```
+Then you can go to tab `visualization -> abstract` to explored the **layered visualization**

--- a/src/py_arg_visualisation/functions/graph_data_functions/get_af_dot_string.py
+++ b/src/py_arg_visualisation/functions/graph_data_functions/get_af_dot_string.py
@@ -8,9 +8,9 @@ from py_arg_visualisation.functions.graph_data_functions.get_color import \
 PATH_TO_ENCODINGS = pathlib.Path(__file__).parent / 'encodings'
 
 
-def generate_plain_dot_string(argumentation_framework):
+def generate_plain_dot_string(argumentation_framework, layout=any):
     dot_string = "digraph {\n"
-    dot_string += "    // Node defaults can be set here if needed\n"
+    dot_string += " rankdir={}  // Node defaults can be set here if needed\n".format(layout)
 
     # Adding node information
     for argument in argumentation_framework.arguments:
@@ -26,11 +26,11 @@ def generate_plain_dot_string(argumentation_framework):
 
 
 def generate_dot_string(
-        argumentation_framework, selected_arguments, color_blind_mode=False):
+        argumentation_framework, selected_arguments, color_blind_mode=False, layout=any):
     gr_status_by_arg, number_by_argument = get_numbered_grounded_extension(
         argumentation_framework)
     dot_string = "digraph {\n"
-    dot_string += "    // Node defaults can be set here if needed\n"
+    dot_string +=" rankdir={}  // Node defaults can be set here if needed\n".format(layout)
 
     # Adding node information
     is_extension_representation = False
@@ -89,7 +89,11 @@ def generate_dot_string(
 
             constraint = False
             style = 'solid'
-            label = from_argument_number
+            try:
+                num = int(from_argument_number)
+                label = str( num + 1)
+            except ValueError:
+                label = from_argument_number
             if from_argument_grounded_state == 'accepted' and \
                     to_argument_grounded_state == 'defeated':
                 full_color = get_color('green', color_blind_mode)
@@ -100,7 +104,7 @@ def generate_dot_string(
                     to_argument_grounded_state == 'defeated':
                 constraint = True
                 full_color = get_color('black', color_blind_mode)
-                style = 'dotted'
+                style = 'dashed'
                 label = ''
             else:
                 grounded_edge_color = get_color('yellow', color_blind_mode)

--- a/src/py_arg_visualisation/pages/21_visualise_abstract.py
+++ b/src/py_arg_visualisation/pages/21_visualise_abstract.py
@@ -185,14 +185,16 @@ right_column = dbc.Col([
                             dash_interactive_graphviz.DashInteractiveGraphviz(
                                 id='explanation-graph',
                                 style={'height': '500px'}
+                            ),
+                            html.Label('Layout:', style={'margin-top': '50px', 'display': 'inline-block'}),
+                            dcc.Dropdown(
+                                placeholder="Layout",
+                                options=['LR', 'RL', 'BT', 'TB'],
+                                value='BT',
+                                id='21-abstract-graph-layout',
+                                clearable=False,
+                                style={'width': '80px', 'position': 'absolute', 'top': '50px', 'left': '33px'}
                             )
-                            # dbc.Checklist(
-                            #     options=[{'label': 'Show contradictories',
-                            #               'value': 'show_contra'}],
-                            #     value=['show_contra'],
-                            #     inline=True, switch=True,
-                            #     id='22-aspic-graph-show-contradictories'
-                            # ),
                             ], style={'height': '500px'})
                     ]),
                 ]))])])
@@ -207,7 +209,7 @@ layout = html.Div([html.H1(
     Output('abstract-attacks', 'value'),
     Input('generate-random-af-button', 'n_clicks'),
     Input('upload-af', 'contents'),
-    State('upload-af', 'filename')
+    State('upload-af', 'filename'),
 )
 def generate_abstract_argumentation_framework(
         _nr_of_clicks_random: int, af_content: str, af_filename: str):
@@ -261,11 +263,13 @@ def generate_abstract_argumentation_framework(
     Input('abstract-attacks', 'value'),
     Input('selected-argument-store-abstract', 'data'),
     Input('color-blind-mode', 'on'),
+    Input('21-abstract-graph-layout', 'value'),
     prevent_initial_call=True
 )
 def create_abstract_argumentation_framework(
         arguments: str, attacks: str, selected_arguments: Dict[str, List[str]],
-        color_blind_mode: bool):
+        color_blind_mode: bool, layout: str):
+    print(layout)
     """
     Send the AF data to the graph for plotting.
     """
@@ -282,10 +286,10 @@ def create_abstract_argumentation_framework(
         arg_framework, selected_arguments, color_blind_mode)
 
     if not selected_arguments:
-        dot_source = generate_plain_dot_string(arg_framework)
+        dot_source = generate_plain_dot_string(arg_framework, layout)
     else:
         dot_source = generate_dot_string(
-            arg_framework, selected_arguments, color_blind_mode)
+            arg_framework, selected_arguments, color_blind_mode,layout)
     return data, dot_source
 
 

--- a/src/py_arg_visualisation/pages/21_visualise_abstract.py
+++ b/src/py_arg_visualisation/pages/21_visualise_abstract.py
@@ -9,403 +9,270 @@ from dash.exceptions import PreventUpdate
 import dash_bootstrap_components as dbc
 import dash_interactive_graphviz
 
-from py_arg.abstract_argumentation.classes.abstract_argumentation_framework import (
-    AbstractArgumentationFramework,
-)
-from py_arg.abstract_argumentation.generators.abstract_argumentation_framework_generator import (
-    AbstractArgumentationFrameworkGenerator,
-)
-from py_arg.abstract_argumentation.import_export.argumentation_framework_from_aspartix_format_reader import (
-    ArgumentationFrameworkFromASPARTIXFormatReader,
-)
-from py_arg.abstract_argumentation.import_export.argumentation_framework_from_iccma23_format_reader import (
-    ArgumentationFrameworkFromICCMA23FormatReader,
-)
-from py_arg.abstract_argumentation.import_export.argumentation_framework_from_json_reader import (
-    ArgumentationFrameworkFromJsonReader,
-)
-from py_arg.abstract_argumentation.import_export.argumentation_framework_from_trivial_graph_format_reader import (
-    ArgumentationFrameworkFromTrivialGraphFormatReader,
-)
-from py_arg.abstract_argumentation.import_export.argumentation_framework_to_aspartix_format_writer import (
-    ArgumentationFrameworkToASPARTIXFormatWriter,
-)
-from py_arg.abstract_argumentation.import_export.argumentation_framework_to_iccma23_format_writer import (
-    ArgumentationFrameworkToICCMA23FormatWriter,
-)
-from py_arg.abstract_argumentation.import_export.argumentation_framework_to_json_writer import (
-    ArgumentationFrameworkToJSONWriter,
-)
-from py_arg.abstract_argumentation.import_export.argumentation_framework_to_trivial_graph_format_writer import (
-    ArgumentationFrameworkToTrivialGraphFormatWriter,
-)
-from py_arg_visualisation.functions.explanations_functions.explanation_function_options import (
-    EXPLANATION_FUNCTION_OPTIONS,
-)
-from py_arg_visualisation.functions.explanations_functions.get_af_explanations import (
-    get_argumentation_framework_explanations,
-)
-from py_arg.abstract_argumentation.semantics.get_accepted_arguments import (
-    get_accepted_arguments,
-)
-from py_arg.abstract_argumentation.semantics.get_argumentation_framework_extensions import (
-    get_argumentation_framework_extensions,
-)
-from py_arg_visualisation.functions.extensions_functions.get_acceptance_strategy import (
-    get_acceptance_strategy,
-)
-from py_arg_visualisation.functions.graph_data_functions.get_af_dot_string import (
-    generate_plain_dot_string,
-    generate_dot_string,
-)
-from py_arg_visualisation.functions.graph_data_functions.get_af_graph_data import (
-    get_argumentation_framework_graph_data,
-)
-from py_arg_visualisation.functions.import_functions.read_argumentation_framework_functions import (
-    read_argumentation_framework,
-)
+from py_arg.abstract_argumentation.classes.abstract_argumentation_framework \
+    import AbstractArgumentationFramework
+from py_arg.abstract_argumentation.generators.\
+    abstract_argumentation_framework_generator import \
+    AbstractArgumentationFrameworkGenerator
+from py_arg.abstract_argumentation.import_export.\
+    argumentation_framework_from_aspartix_format_reader import \
+    ArgumentationFrameworkFromASPARTIXFormatReader
+from py_arg.abstract_argumentation.import_export.\
+    argumentation_framework_from_iccma23_format_reader import \
+    ArgumentationFrameworkFromICCMA23FormatReader
+from py_arg.abstract_argumentation.import_export.\
+    argumentation_framework_from_json_reader import \
+    ArgumentationFrameworkFromJsonReader
+from py_arg.abstract_argumentation.import_export.\
+    argumentation_framework_from_trivial_graph_format_reader import \
+    ArgumentationFrameworkFromTrivialGraphFormatReader
+from py_arg.abstract_argumentation.import_export.\
+    argumentation_framework_to_aspartix_format_writer import \
+    ArgumentationFrameworkToASPARTIXFormatWriter
+from py_arg.abstract_argumentation.import_export.\
+    argumentation_framework_to_iccma23_format_writer import \
+    ArgumentationFrameworkToICCMA23FormatWriter
+from py_arg.abstract_argumentation.import_export.\
+    argumentation_framework_to_json_writer import \
+    ArgumentationFrameworkToJSONWriter
+from py_arg.abstract_argumentation.import_export.\
+    argumentation_framework_to_trivial_graph_format_writer import \
+    ArgumentationFrameworkToTrivialGraphFormatWriter
+from py_arg_visualisation.functions.explanations_functions.\
+    explanation_function_options import \
+    EXPLANATION_FUNCTION_OPTIONS
+from py_arg_visualisation.functions.explanations_functions.\
+    get_af_explanations import \
+    get_argumentation_framework_explanations
+from py_arg.abstract_argumentation.semantics.get_accepted_arguments import \
+    get_accepted_arguments
+from py_arg.abstract_argumentation.semantics.\
+    get_argumentation_framework_extensions import \
+    get_argumentation_framework_extensions
+from py_arg_visualisation.functions.extensions_functions.\
+    get_acceptance_strategy import get_acceptance_strategy
+from py_arg_visualisation.functions.graph_data_functions.get_af_dot_string \
+    import generate_plain_dot_string, generate_dot_string
+from py_arg_visualisation.functions.graph_data_functions.\
+    get_af_graph_data import get_argumentation_framework_graph_data
+from py_arg_visualisation.functions.import_functions.\
+    read_argumentation_framework_functions import \
+    read_argumentation_framework
 
-dash.register_page(__name__, name="Visualise AF", title="Visualise AF")
+dash.register_page(__name__, name='Visualise AF', title='Visualise AF')
 
 
 # Create layout elements and compose them into the layout for this page.
 
-
 def get_abstract_setting_specification_div():
-    return html.Div(
-        children=[
-            dcc.Store(id="selected-argument-store-abstract"),
-            dbc.Col(
-                [
-                    dbc.Row(
-                        [
-                            dbc.Col(
-                                dbc.Button(
-                                    "Generate random",
-                                    id="generate-random-af-button",
-                                    n_clicks=0,
-                                    className="w-100",
-                                )
-                            ),
-                            dbc.Col(
-                                dcc.Upload(
-                                    dbc.Button("Open existing AF", className="w-100"),
-                                    id="upload-af",
-                                )
-                            ),
-                        ],
-                        className="mt-2",
-                    ),
-                    dbc.Row(
-                        [
-                            dbc.Col(
-                                [
-                                    html.B("Arguments"),
-                                    dbc.Textarea(
-                                        id="abstract-arguments",
-                                        placeholder="Add one argument per line. "
-                                        "For example:\n A\n B\n C",
-                                        value="",
-                                        style={"height": "300px"},
-                                    ),
-                                ]
-                            ),
-                            dbc.Col(
-                                [
-                                    html.B("Attacks"),
-                                    dbc.Textarea(
-                                        id="abstract-attacks",
-                                        placeholder="Add one attack per line. "
-                                        "For example: \n (A,B) \n (A,C) \n (C,B)",
-                                        value="",
-                                        style={"height": "300px"},
-                                    ),
-                                ]
-                            ),
-                        ],
-                        className="mt-2",
-                    ),
-                    dbc.Row(
-                        [
-                            dbc.InputGroup(
-                                [
-                                    dbc.InputGroupText("Filename"),
-                                    dbc.Input(value="edited_af", id="21-af-filename"),
-                                    dbc.InputGroupText("."),
-                                    dbc.Select(
-                                        options=[
-                                            {"label": extension, "value": extension}
-                                            for extension in [
-                                                "JSON",
-                                                "TGF",
-                                                "APX",
-                                                "ICCMA23",
-                                            ]
-                                        ],
-                                        value="JSON",
-                                        id="21-af-extension",
-                                    ),
-                                    dbc.Button("Download", id="21-af-download-button"),
-                                ],
-                                className="mt-2",
-                            ),
-                            dcc.Download(id="21-af-download"),
-                        ]
-                    ),
-                ]
-            ),
-        ]
-    )
+    return html.Div(children=[
+        dcc.Store(id='selected-argument-store-abstract'),
+        dbc.Col([
+            dbc.Row([dbc.Col(dbc.Button(
+                'Generate random',
+                id='generate-random-af-button', n_clicks=0,
+                className='w-100')),
+                     dbc.Col(dcc.Upload(dbc.Button(
+                         'Open existing AF', className='w-100'),
+                         id='upload-af'))
+                     ], className='mt-2'),
+            dbc.Row([
+                dbc.Col([
+                    html.B('Arguments'),
+                    dbc.Textarea(
+                        id='abstract-arguments',
+                        placeholder='Add one argument per line. '
+                                    'For example:\n A\n B\n C',
+                        value='', style={'height': '300px'})
+                ]),
+                dbc.Col([
+                    html.B('Attacks'),
+                    dbc.Textarea(
+                        id='abstract-attacks',
+                        placeholder='Add one attack per line. '
+                                    'For example: \n (A,B) \n (A,C) \n (C,B)',
+                        value='', style={'height': '300px'}),
+                ])
+            ], className='mt-2'),
+            dbc.Row([
+                dbc.InputGroup([
+                    dbc.InputGroupText('Filename'),
+                    dbc.Input(value='edited_af', id='21-af-filename'),
+                    dbc.InputGroupText('.'),
+                    dbc.Select(
+                        options=[{'label': extension, 'value': extension}
+                                 for extension in ['JSON', 'TGF', 'APX',
+                                                   'ICCMA23']],
+                        value='JSON', id='21-af-extension'),
+                    dbc.Button('Download', id='21-af-download-button'),
+                ], className='mt-2'),
+                dcc.Download(id='21-af-download')
+            ])
+        ])
+    ])
 
 
 def get_abstract_evaluation_div():
-    return html.Div(
-        [
-            html.Div(
-                [
-                    dbc.Row(
-                        [
-                            dbc.Col(html.B("Semantics")),
-                            dbc.Col(
-                                dbc.Select(
-                                    options=[
-                                        {"label": "Admissible", "value": "Admissible"},
-                                        {"label": "Complete", "value": "Complete"},
-                                        {"label": "Grounded", "value": "Grounded"},
-                                        {"label": "Preferred", "value": "Preferred"},
-                                        {"label": "Ideal", "value": "Ideal"},
-                                        {"label": "Stable", "value": "Stable"},
-                                        {"label": "Semi-stable", "value": "SemiStable"},
-                                        {"label": "Eager", "value": "Eager"},
-                                        {
-                                            "label": "Conflict-free",
-                                            "value": "ConflictFree",
-                                        },
-                                        {"label": "Naive", "value": "Naive"},
-                                    ],
-                                    value="Complete",
-                                    id="abstract-evaluation-semantics",
-                                )
-                            ),
-                        ]
-                    ),
-                    dbc.Row(
-                        [
-                            dbc.Col(html.B("Evaluation strategy")),
-                            dbc.Col(
-                                dbc.Select(
-                                    options=[
-                                        {"label": "Credulous", "value": "Credulous"},
-                                        {"label": "Skeptical", "value": "Skeptical"},
-                                    ],
-                                    value="Credulous",
-                                    id="abstract-evaluation-strategy",
-                                )
-                            ),
-                        ]
-                    ),
-                    dbc.Row(id="abstract-evaluation"),
-                ]
-            ),
-        ]
-    )
+    return html.Div([
+        html.Div([
+            dbc.Row([
+                dbc.Col(html.B('Semantics')),
+                dbc.Col(dbc.Select(options=[
+                    {'label': 'Admissible', 'value': 'Admissible'},
+                    {'label': 'Complete', 'value': 'Complete'},
+                    {'label': 'Grounded', 'value': 'Grounded'},
+                    {'label': 'Preferred', 'value': 'Preferred'},
+                    {'label': 'Ideal', 'value': 'Ideal'},
+                    {'label': 'Stable', 'value': 'Stable'},
+                    {'label': 'Semi-stable', 'value': 'SemiStable'},
+                    {'label': 'Eager', 'value': 'Eager'},
+                    {'label': 'Conflict-free', 'value': 'ConflictFree'},
+                    {'label': 'Naive', 'value': 'Naive'}
+                ], value='Complete', id='abstract-evaluation-semantics')),
+            ]),
+
+            dbc.Row([
+                dbc.Col(html.B('Evaluation strategy')),
+                dbc.Col(dbc.Select(
+                    options=[
+                        {'label': 'Credulous', 'value': 'Credulous'},
+                        {'label': 'Skeptical', 'value': 'Skeptical'}
+                    ], value='Credulous', id='abstract-evaluation-strategy')),
+            ]),
+            dbc.Row(id='abstract-evaluation')
+        ]),
+    ])
 
 
 def get_abstract_explanation_div():
-    return html.Div(
-        [
-            dbc.Row(
-                [
-                    dbc.Col(html.B("Type")),
-                    dbc.Col(
-                        dbc.Select(
-                            options=[
-                                {"label": "Acceptance", "value": "Acceptance"},
-                                {"label": "Non-Acceptance", "value": "NonAcceptance"},
-                            ],
-                            value="Acceptance",
-                            id="abstract-explanation-type",
-                        )
-                    ),
-                ]
-            ),
-            dbc.Row(
-                [
-                    dbc.Col(html.B("Explanation function")),
-                    dbc.Col(dbc.Select(id="abstract-explanation-function")),
-                ]
-            ),
-            dbc.Row(id="abstract-explanation"),
-        ]
-    )
+    return html.Div([
+        dbc.Row([
+            dbc.Col(html.B('Type')),
+            dbc.Col(dbc.Select(
+                options=[{'label': 'Acceptance', 'value': 'Acceptance'},
+                         {'label': 'Non-Acceptance',
+                          'value': 'NonAcceptance'}],
+                value='Acceptance', id='abstract-explanation-type'))]),
+        dbc.Row([
+            dbc.Col(html.B('Explanation function')),
+            dbc.Col(dbc.Select(id='abstract-explanation-function'))
+        ]),
+        dbc.Row(id='abstract-explanation')
+    ])
 
 
 left_column = dbc.Col(
-    dbc.Accordion(
-        [
-            dbc.AccordionItem(
-                get_abstract_setting_specification_div(),
-                title="Abstract Argumentation Framework",
-                item_id="Plain_AF",
-            ),
-            dbc.AccordionItem(
-                get_abstract_evaluation_div(), title="Evaluation", item_id="Evaluation"
-            ),
-            dbc.AccordionItem(
-                get_abstract_explanation_div(),
-                title="Explanation",
-                item_id="Explanation",
-            ),
-        ],
-        id="abstract-evaluation-accordion",
-    )
+    dbc.Accordion([
+        dbc.AccordionItem(get_abstract_setting_specification_div(),
+                          title='Abstract Argumentation Framework',
+                          item_id="Plain_AF"),
+        dbc.AccordionItem(get_abstract_evaluation_div(),
+                          title='Evaluation', item_id='Evaluation'),
+        dbc.AccordionItem(get_abstract_explanation_div(),
+                          title='Explanation', item_id='Explanation')
+    ], id='abstract-evaluation-accordion')
 )
 
-right_column = dbc.Col(
-    [
-        dbc.Row(
-            [
-                dbc.Card(
-                    dcc.Tabs(
-                        [
-                            dcc.Tab(
-                                label="Default visualisation",
-                                children=[
-                                    visdcc.Network(
-                                        data={"nodes": [], "edges": []},
-                                        id="abstract-argumentation-graph",
-                                        options={"height": "500px"},
-                                    )
-                                ],
+right_column = dbc.Col([
+        dbc.Row([
+            dbc.Card(
+                dcc.Tabs([
+                    dcc.Tab(label='Default visualisation', children=[
+                        visdcc.Network(data={'nodes': [], 'edges': []},
+                                       id='abstract-argumentation-graph',
+                                       options={'height': '500px'})]),
+                    dcc.Tab(label='Layered visualisation', children=[
+                        html.Div([
+                            dash_interactive_graphviz.DashInteractiveGraphviz(
+                                id='explanation-graph',
+                                style={'height': '500px'}
                             ),
-                            dcc.Tab(
-                                label="Layered visualisation",
-                                children=[
-                                    html.Div(
-                                        [
-                                            dash_interactive_graphviz.DashInteractiveGraphviz(
-                                                id="explanation-graph",
-                                                style={"height": "500px"},
-                                            ),
-                                            html.Label(
-                                                "Layout:",
-                                                style={
-                                                    "margin-top": "50px",
-                                                    "display": "inline-block",
-                                                },
-                                            ),
-                                            dcc.Dropdown(
-                                                placeholder="Layout",
-                                                options=["LR", "RL", "BT", "TB"],
-                                                value="BT",
-                                                id="21-abstract-graph-layout",
-                                                clearable=False,
-                                                style={
-                                                    "width": "80px",
-                                                    "position": "absolute",
-                                                    "top": "50px",
-                                                    "left": "33px",
-                                                },
-                                            ),
-                                        ],
-                                        style={"height": "500px"},
-                                    )
-                                ],
-                            ),
-                        ]
-                    )
-                )
-            ]
-        )
-    ]
-)
+                            html.Label('Layout:', style={'margin-top': '50px', 'display': 'inline-block'}),
+                            dcc.Dropdown(
+                                placeholder="Layout",
+                                options=['LR', 'RL', 'BT', 'TB'],
+                                value='BT',
+                                id='21-abstract-graph-layout',
+                                clearable=False,
+                                style={'width': '80px', 'position': 'absolute', 'top': '50px', 'left': '33px'}
+                            )
+                            ], style={'height': '500px'})
+                    ]),
+                ]))])])
 
 layout_abstract = dbc.Row([left_column, right_column])
-layout = html.Div(
-    [html.H1("Visualisation of abstract argumentation frameworks"), layout_abstract]
-)
+layout = html.Div([html.H1(
+    'Visualisation of abstract argumentation frameworks'), layout_abstract])
 
 
 @callback(
-    Output("abstract-arguments", "value"),
-    Output("abstract-attacks", "value"),
-    Input("generate-random-af-button", "n_clicks"),
-    Input("upload-af", "contents"),
-    State("upload-af", "filename"),
+    Output('abstract-arguments', 'value'),
+    Output('abstract-attacks', 'value'),
+    Input('generate-random-af-button', 'n_clicks'),
+    Input('upload-af', 'contents'),
+    State('upload-af', 'filename'),
 )
 def generate_abstract_argumentation_framework(
-    _nr_of_clicks_random: int, af_content: str, af_filename: str
-):
+        _nr_of_clicks_random: int, af_content: str, af_filename: str):
     """
     Generate a random AF after clicking the button and put the result in the
     text box.
     """
-    if dash.callback_context.triggered_id == "generate-random-af-button":
-        random_af = AbstractArgumentationFrameworkGenerator(8, 8, True).generate()
-        abstract_arguments_value = "\n".join((str(arg) for arg in random_af.arguments))
-        abstract_attacks_value = "\n".join(
-            (
-                f"({str(defeat.from_argument)}," f"{str(defeat.to_argument)})"
-                for defeat in random_af.defeats
-            )
-        )
+    if dash.callback_context.triggered_id == 'generate-random-af-button':
+        random_af = \
+            AbstractArgumentationFrameworkGenerator(8, 8, True).generate()
+        abstract_arguments_value = '\n'.join((str(arg)
+                                              for arg in random_af.arguments))
+        abstract_attacks_value = '\n'.join((f'({str(defeat.from_argument)},'
+                                            f'{str(defeat.to_argument)})'
+                                            for defeat in random_af.defeats))
         return abstract_arguments_value, abstract_attacks_value
-    elif dash.callback_context.triggered_id == "upload-af":
-        content_type, content_str = af_content.split(",")
+    elif dash.callback_context.triggered_id == 'upload-af':
+        content_type, content_str = af_content.split(',')
         decoded = base64.b64decode(content_str)
 
-        name = af_filename.split(".")[0]
-        if af_filename.upper().endswith(".JSON"):
+        name = af_filename.split('.')[0]
+        if af_filename.upper().endswith('.JSON'):
             opened_af = ArgumentationFrameworkFromJsonReader().from_json(
-                json.loads(decoded)
-            )
-        elif af_filename.upper().endswith(".TGF"):
-            opened_af = ArgumentationFrameworkFromTrivialGraphFormatReader.from_tgf(
-                decoded.decode(), name
-            )
-        elif af_filename.upper().endswith(".APX"):
-            opened_af = ArgumentationFrameworkFromASPARTIXFormatReader.from_apx(
-                decoded.decode(), name
-            )
-        elif af_filename.upper().endswith(".ICCMA23"):
-            opened_af = ArgumentationFrameworkFromICCMA23FormatReader.from_iccma23(
-                decoded.decode(), name
-            )
+                json.loads(decoded))
+        elif af_filename.upper().endswith('.TGF'):
+            opened_af = ArgumentationFrameworkFromTrivialGraphFormatReader.\
+                from_tgf(decoded.decode(), name)
+        elif af_filename.upper().endswith('.APX'):
+            opened_af = ArgumentationFrameworkFromASPARTIXFormatReader.\
+                from_apx(decoded.decode(), name)
+        elif af_filename.upper().endswith('.ICCMA23'):
+            opened_af = ArgumentationFrameworkFromICCMA23FormatReader.\
+                from_iccma23(decoded.decode(), name)
         else:
-            raise NotImplementedError("This file format is currently not " "supported.")
+            raise NotImplementedError('This file format is currently not '
+                                      'supported.')
 
-        abstract_arguments_value = "\n".join((str(arg) for arg in opened_af.arguments))
-        abstract_attacks_value = "\n".join(
-            (
-                f"({str(defeat.from_argument)}," f"{str(defeat.to_argument)})"
-                for defeat in opened_af.defeats
-            )
-        )
+        abstract_arguments_value = '\n'.join((str(arg)
+                                              for arg in opened_af.arguments))
+        abstract_attacks_value = '\n'.join((f'({str(defeat.from_argument)},'
+                                            f'{str(defeat.to_argument)})'
+                                            for defeat in opened_af.defeats))
         return abstract_arguments_value, abstract_attacks_value
-    return "", ""
+    return '', ''
 
 
 @callback(
-    Output("abstract-argumentation-graph", "data"),
-    Output("explanation-graph", "dot_source"),
-    Input("abstract-arguments", "value"),
-    Input("abstract-attacks", "value"),
-    Input("selected-argument-store-abstract", "data"),
-    Input("color-blind-mode", "on"),
-    Input("21-abstract-graph-layout", "value"),
+    Output('abstract-argumentation-graph', 'data'),
+    Output('explanation-graph', 'dot_source'),
+    Input('abstract-arguments', 'value'),
+    Input('abstract-attacks', 'value'),
+    Input('selected-argument-store-abstract', 'data'),
+    Input('color-blind-mode', 'on'),
+    Input('21-abstract-graph-layout', 'value'),
     Input("abstract-evaluation-accordion", "active_item"),
     State("selected-argument-store-abstract", "data"),
-    prevent_initial_call=True,
+    prevent_initial_call=True
 )
 def create_abstract_argumentation_framework(
-    arguments: str,
-    attacks: str,
-    selected_arguments: Dict[str, List[str]],
-    color_blind_mode: bool,
-    dot_layout: str,
-    active_item: str,
-    stored_selected_arguments: Dict[str, List[str]],
-):
+        arguments: str, attacks: str, selected_arguments: Dict[str, List[str]],
+        color_blind_mode: bool, dot_layout: str, active_item: str,
+        stored_selected_arguments: Dict[str, List[str]],):
     """
     Send the AF data to the graph for plotting.
     """
@@ -414,12 +281,12 @@ def create_abstract_argumentation_framework(
     except ValueError:
         arg_framework = AbstractArgumentationFramework()
 
-    if dash.callback_context.triggered_id != "selected-argument-store-abstract":
+    if dash.callback_context.triggered_id != \
+            'selected-argument-store-abstract':
         selected_arguments = None
 
     data = get_argumentation_framework_graph_data(
-        arg_framework, selected_arguments, color_blind_mode
-    )
+        arg_framework, selected_arguments, color_blind_mode)
 
     if active_item == "Plain_AF" or not stored_selected_arguments:
         dot_source = generate_plain_dot_string(arg_framework, dot_layout)
@@ -432,240 +299,193 @@ def create_abstract_argumentation_framework(
         dot_source = generate_dot_string(
             arg_framework, selected_arguments, color_blind_mode, dot_layout
         )
-
     return data, dot_source
 
 
 @callback(
-    Output("21-af-download", "data"),
-    Input("21-af-download-button", "n_clicks"),
-    State("abstract-arguments", "value"),
-    State("abstract-attacks", "value"),
-    State("21-af-filename", "value"),
-    State("21-af-extension", "value"),
+    Output('21-af-download', 'data'),
+    Input('21-af-download-button', 'n_clicks'),
+    State('abstract-arguments', 'value'),
+    State('abstract-attacks', 'value'),
+    State('21-af-filename', 'value'),
+    State('21-af-extension', 'value'),
     prevent_initial_call=True,
 )
 def download_generated_abstract_argumentation_framework(
-    _nr_clicks: int,
-    arguments_text: str,
-    defeats_text: str,
-    filename: str,
-    extension: str,
-):
-    argumentation_framework = read_argumentation_framework(arguments_text, defeats_text)
+        _nr_clicks: int, arguments_text: str, defeats_text: str, filename: str,
+        extension: str):
+    argumentation_framework = read_argumentation_framework(arguments_text,
+                                                           defeats_text)
 
-    if extension == "JSON":
-        argumentation_framework_json = ArgumentationFrameworkToJSONWriter().to_dict(
-            argumentation_framework
-        )
+    if extension == 'JSON':
+        argumentation_framework_json = \
+            ArgumentationFrameworkToJSONWriter().to_dict(
+                argumentation_framework)
         argumentation_framework_str = json.dumps(argumentation_framework_json)
-    elif extension == "TGF":
-        argumentation_framework_str = (
+    elif extension == 'TGF':
+        argumentation_framework_str = \
             ArgumentationFrameworkToTrivialGraphFormatWriter.write_to_str(
-                argumentation_framework
-            )
-        )
-    elif extension == "APX":
-        argumentation_framework_str = (
+                argumentation_framework)
+    elif extension == 'APX':
+        argumentation_framework_str = \
             ArgumentationFrameworkToASPARTIXFormatWriter.write_to_str(
-                argumentation_framework
-            )
-        )
-    elif extension == "ICCMA23":
-        argumentation_framework_str = (
+                argumentation_framework)
+    elif extension == 'ICCMA23':
+        argumentation_framework_str = \
             ArgumentationFrameworkToICCMA23FormatWriter.write_to_str(
-                argumentation_framework
-            )
-        )
+                argumentation_framework)
     else:
         raise NotImplementedError
 
-    return {
-        "content": argumentation_framework_str,
-        "filename": filename + "." + extension,
-    }
+    return {'content': argumentation_framework_str,
+            'filename': filename + '.' + extension}
 
 
 @callback(
-    Output("abstract-evaluation", "children"),
-    State("abstract-arguments", "value"),
-    State("abstract-attacks", "value"),
-    Input("abstract-evaluation-accordion", "active_item"),
-    Input("abstract-evaluation-semantics", "value"),
-    Input("abstract-evaluation-strategy", "value"),
-    prevent_initial_call=True,
+    Output('abstract-evaluation', 'children'),
+    State('abstract-arguments', 'value'),
+    State('abstract-attacks', 'value'),
+    Input('abstract-evaluation-accordion', 'active_item'),
+    Input('abstract-evaluation-semantics', 'value'),
+    Input('abstract-evaluation-strategy', 'value'),
+    prevent_initial_call=True
 )
-def evaluate_abstract_argumentation_framework(
-    arguments: str, attacks: str, active_item: str, semantics: str, strategy: str
-):
-    if active_item != "Evaluation":
+def evaluate_abstract_argumentation_framework(arguments: str, attacks: str,
+                                              active_item: str,
+                                              semantics: str, strategy: str):
+    if active_item != 'Evaluation':
         raise PreventUpdate
 
     # Read the abstract argumentation framework.
     arg_framework = read_argumentation_framework(arguments, attacks)
 
     # Compute the extensions and put them in a list of sets.
-    frozen_extensions = get_argumentation_framework_extensions(arg_framework, semantics)
-    extensions = [set(frozen_extension) for frozen_extension in frozen_extensions]
+    frozen_extensions = get_argumentation_framework_extensions(arg_framework,
+                                                               semantics)
+    extensions = [set(frozen_extension)
+                  for frozen_extension in frozen_extensions]
 
     # Make a button for each extension.
     extension_buttons = []
     for extension in sorted(extensions):
-        out_arguments = {
-            attacked
-            for attacked in arg_framework.arguments
-            if any(
-                argument in arg_framework.get_incoming_defeat_arguments(attacked)
-                for argument in extension
-            )
-        }
-        undecided_arguments = {
-            argument
-            for argument in arg_framework.arguments
-            if argument not in extension and argument not in out_arguments
-        }
-        extension_readable_str = (
-            "{" + ", ".join(argument.name for argument in sorted(extension)) + "}"
-        )
-        extension_in_str = "+".join(argument.name for argument in sorted(extension))
-        extension_out_str = "+".join(
-            argument.name for argument in sorted(out_arguments)
-        )
-        extension_undecided_str = "+".join(
-            argument.name for argument in sorted(undecided_arguments)
-        )
-        extension_long_str = "|".join(
-            [extension_in_str, extension_undecided_str, extension_out_str]
-        )
+        out_arguments = {attacked for attacked in arg_framework.arguments
+                         if any(argument in arg_framework.
+                                get_incoming_defeat_arguments(attacked)
+                                for argument in extension)}
+        undecided_arguments = {argument for argument in arg_framework.arguments
+                               if argument not in extension and
+                               argument not in out_arguments}
+        extension_readable_str = \
+            '{' + ', '.join(argument.name
+                            for argument in sorted(extension)) + '}'
+        extension_in_str = \
+            '+'.join(argument.name for argument in sorted(extension))
+        extension_out_str = \
+            '+'.join(argument.name for argument in sorted(out_arguments))
+        extension_undecided_str = \
+            '+'.join(argument.name for argument in sorted(undecided_arguments))
+        extension_long_str = \
+            '|'.join([extension_in_str, extension_undecided_str,
+                      extension_out_str])
         extension_buttons.append(
-            dbc.Button(
-                [extension_readable_str],
-                color="secondary",
-                id={"type": "extension-button-abstract", "index": extension_long_str},
-            )
-        )
+            dbc.Button([extension_readable_str], color='secondary',
+                       id={'type': 'extension-button-abstract',
+                           'index': extension_long_str}))
 
     # Based on the extensions, get the acceptance status of arguments.
     acceptance_strategy = get_acceptance_strategy(strategy)
-    accepted_arguments = get_accepted_arguments(frozen_extensions, acceptance_strategy)
+    accepted_arguments = get_accepted_arguments(
+        frozen_extensions, acceptance_strategy)
 
     # Make a button for each accepted argument.
     accepted_argument_buttons = [
-        dbc.Button(
-            argument.name,
-            color="secondary",
-            id={"type": "argument-button-abstract", "index": argument.name},
-        )
-        for argument in sorted(accepted_arguments)
-    ]
+        dbc.Button(argument.name, color='secondary',
+                   id={'type': 'argument-button-abstract',
+                       'index': argument.name})
+        for argument in sorted(accepted_arguments)]
 
-    return html.Div(
-        [
-            html.B("The extension(s):"),
-            html.Div(extension_buttons),
-            html.B("The accepted argument(s):"),
-            html.Div(accepted_argument_buttons),
-            html.P(
-                "Click on the extension/argument buttons to "
-                "display the corresponding argument(s) "
-                "in the graph."
-            ),
-        ]
-    )
+    return html.Div([html.B('The extension(s):'), html.Div(extension_buttons),
+                     html.B('The accepted argument(s):'),
+                     html.Div(accepted_argument_buttons),
+                     html.P('Click on the extension/argument buttons to '
+                            'display the corresponding argument(s) '
+                            'in the graph.')])
 
 
 @callback(
-    Output("selected-argument-store-abstract", "data"),
-    Input({"type": "extension-button-abstract", "index": ALL}, "n_clicks"),
-    Input({"type": "argument-button-abstract", "index": ALL}, "n_clicks"),
-    State("selected-argument-store-abstract", "data"),
+    Output('selected-argument-store-abstract', 'data'),
+    Input({'type': 'extension-button-abstract', 'index': ALL}, 'n_clicks'),
+    Input({'type': 'argument-button-abstract', 'index': ALL}, 'n_clicks'),
+    State('selected-argument-store-abstract', 'data'),
 )
-def mark_extension_or_argument_in_graph(
-    _nr_of_clicks_extension_values,
-    _nr_of_clicks_argument_values,
-    old_selected_data: List[str],
-):
-    button_clicked_id = dash.callback_context.triggered[0]["prop_id"].split(".")[0]
-    if button_clicked_id == "":
+def mark_extension_or_argument_in_graph(_nr_of_clicks_extension_values,
+                                        _nr_of_clicks_argument_values,
+                                        old_selected_data: List[str]):
+    button_clicked_id = \
+        dash.callback_context.triggered[0]['prop_id'].split('.')[0]
+    if button_clicked_id == '':
         return old_selected_data
     button_clicked_id_content = json.loads(button_clicked_id)
-    button_clicked_id_type = button_clicked_id_content["type"]
-    button_clicked_id_index = button_clicked_id_content["index"]
-    if button_clicked_id_type == "extension-button-abstract":
-        in_part, undecided_part, out_part = button_clicked_id_index.split("|", 3)
-        return {
-            "green": in_part.split("+"),
-            "yellow": undecided_part.split("+"),
-            "red": out_part.split("+"),
-        }
-    elif button_clicked_id_type == "argument-button-abstract":
-        return {"blue": [button_clicked_id_index]}
+    button_clicked_id_type = button_clicked_id_content['type']
+    button_clicked_id_index = button_clicked_id_content['index']
+    if button_clicked_id_type == 'extension-button-abstract':
+        in_part, undecided_part, out_part = \
+            button_clicked_id_index.split('|', 3)
+        return {'green': in_part.split('+'),
+                'yellow': undecided_part.split('+'),
+                'red': out_part.split('+')}
+    elif button_clicked_id_type == 'argument-button-abstract':
+        return {'blue': [button_clicked_id_index]}
     return []
 
 
 @callback(
-    Output("abstract-explanation-function", "options"),
-    Output("abstract-explanation-function", "value"),
-    [Input("abstract-explanation-type", "value")],
+    Output('abstract-explanation-function', 'options'),
+    Output('abstract-explanation-function', 'value'),
+    [Input('abstract-explanation-type', 'value')]
 )
 def setting_choice(choice: str):
-    return EXPLANATION_FUNCTION_OPTIONS[choice], EXPLANATION_FUNCTION_OPTIONS[choice][
-        0
-    ]["value"]
+    return EXPLANATION_FUNCTION_OPTIONS[choice], \
+        EXPLANATION_FUNCTION_OPTIONS[choice][0]['value']
 
 
 @callback(
-    Output("abstract-explanation", "children"),
-    Input("abstract-evaluation-accordion", "active_item"),
-    State("abstract-arguments", "value"),
-    State("abstract-attacks", "value"),
-    State("abstract-evaluation-semantics", "value"),
-    Input("abstract-explanation-function", "value"),
-    Input("abstract-explanation-type", "value"),
-    State("abstract-evaluation-strategy", "value"),
-    prevent_initial_call=True,
+    Output('abstract-explanation', 'children'),
+    Input('abstract-evaluation-accordion', 'active_item'),
+    State('abstract-arguments', 'value'),
+    State('abstract-attacks', 'value'),
+    State('abstract-evaluation-semantics', 'value'),
+    Input('abstract-explanation-function', 'value'),
+    Input('abstract-explanation-type', 'value'),
+    State('abstract-evaluation-strategy', 'value'),
+    prevent_initial_call=True
 )
 def derive_explanations_abstract_argumentation_framework(
-    active_item,
-    arguments: str,
-    attacks: str,
-    semantics: str,
-    explanation_function: str,
-    explanation_type: str,
-    explanation_strategy: str,
-):
-    if active_item != "Explanation":
+        active_item, arguments: str, attacks: str, semantics: str,
+        explanation_function: str, explanation_type: str,
+        explanation_strategy: str):
+    if active_item != 'Explanation':
         raise PreventUpdate
 
     # Compute the explanations based on the input.
     arg_framework = read_argumentation_framework(arguments, attacks)
-    frozen_extensions = get_argumentation_framework_extensions(arg_framework, semantics)
-    extensions = [set(frozen_extension) for frozen_extension in frozen_extensions]
+    frozen_extensions = get_argumentation_framework_extensions(arg_framework,
+                                                               semantics)
+    extensions = [set(frozen_extension)
+                  for frozen_extension in frozen_extensions]
     acceptance_strategy = get_acceptance_strategy(explanation_strategy)
-    accepted_arguments = get_accepted_arguments(frozen_extensions, acceptance_strategy)
+    accepted_arguments = get_accepted_arguments(
+        frozen_extensions, acceptance_strategy)
     explanations = get_argumentation_framework_explanations(
-        arg_framework,
-        extensions,
-        accepted_arguments,
-        explanation_function,
-        explanation_type,
-    )
+        arg_framework, extensions, accepted_arguments,
+        explanation_function, explanation_type)
 
     # Print the explanations for each of the arguments.
-    return html.Div(
-        [html.Div(html.B("Explanation(s) by argument:"))]
-        + [
-            html.Div(
-                [
-                    html.B(explanation_key),
-                    html.Ul(
-                        [
-                            html.Li(str(explanation_value).replace("set()", "{}"))
-                            for explanation_value in explanation_values
-                        ]
-                    ),
-                ]
-            )
-            for explanation_key, explanation_values in explanations.items()
-        ]
-    )
+    return html.Div([html.Div(html.B('Explanation(s) by argument:'))] +
+                    [html.Div([
+                        html.B(explanation_key),
+                        html.Ul([html.Li(str(explanation_value).replace(
+                            'set()', '{}'))
+                            for explanation_value in explanation_values])])
+                     for explanation_key, explanation_values in
+                        explanations.items()])

--- a/src/py_arg_visualisation/pages/21_visualise_abstract.py
+++ b/src/py_arg_visualisation/pages/21_visualise_abstract.py
@@ -9,267 +9,403 @@ from dash.exceptions import PreventUpdate
 import dash_bootstrap_components as dbc
 import dash_interactive_graphviz
 
-from py_arg.abstract_argumentation.classes.abstract_argumentation_framework \
-    import AbstractArgumentationFramework
-from py_arg.abstract_argumentation.generators.\
-    abstract_argumentation_framework_generator import \
-    AbstractArgumentationFrameworkGenerator
-from py_arg.abstract_argumentation.import_export.\
-    argumentation_framework_from_aspartix_format_reader import \
-    ArgumentationFrameworkFromASPARTIXFormatReader
-from py_arg.abstract_argumentation.import_export.\
-    argumentation_framework_from_iccma23_format_reader import \
-    ArgumentationFrameworkFromICCMA23FormatReader
-from py_arg.abstract_argumentation.import_export.\
-    argumentation_framework_from_json_reader import \
-    ArgumentationFrameworkFromJsonReader
-from py_arg.abstract_argumentation.import_export.\
-    argumentation_framework_from_trivial_graph_format_reader import \
-    ArgumentationFrameworkFromTrivialGraphFormatReader
-from py_arg.abstract_argumentation.import_export.\
-    argumentation_framework_to_aspartix_format_writer import \
-    ArgumentationFrameworkToASPARTIXFormatWriter
-from py_arg.abstract_argumentation.import_export.\
-    argumentation_framework_to_iccma23_format_writer import \
-    ArgumentationFrameworkToICCMA23FormatWriter
-from py_arg.abstract_argumentation.import_export.\
-    argumentation_framework_to_json_writer import \
-    ArgumentationFrameworkToJSONWriter
-from py_arg.abstract_argumentation.import_export.\
-    argumentation_framework_to_trivial_graph_format_writer import \
-    ArgumentationFrameworkToTrivialGraphFormatWriter
-from py_arg_visualisation.functions.explanations_functions.\
-    explanation_function_options import \
-    EXPLANATION_FUNCTION_OPTIONS
-from py_arg_visualisation.functions.explanations_functions.\
-    get_af_explanations import \
-    get_argumentation_framework_explanations
-from py_arg.abstract_argumentation.semantics.get_accepted_arguments import \
-    get_accepted_arguments
-from py_arg.abstract_argumentation.semantics.\
-    get_argumentation_framework_extensions import \
-    get_argumentation_framework_extensions
-from py_arg_visualisation.functions.extensions_functions.\
-    get_acceptance_strategy import get_acceptance_strategy
-from py_arg_visualisation.functions.graph_data_functions.get_af_dot_string \
-    import generate_plain_dot_string, generate_dot_string
-from py_arg_visualisation.functions.graph_data_functions.\
-    get_af_graph_data import get_argumentation_framework_graph_data
-from py_arg_visualisation.functions.import_functions.\
-    read_argumentation_framework_functions import \
-    read_argumentation_framework
+from py_arg.abstract_argumentation.classes.abstract_argumentation_framework import (
+    AbstractArgumentationFramework,
+)
+from py_arg.abstract_argumentation.generators.abstract_argumentation_framework_generator import (
+    AbstractArgumentationFrameworkGenerator,
+)
+from py_arg.abstract_argumentation.import_export.argumentation_framework_from_aspartix_format_reader import (
+    ArgumentationFrameworkFromASPARTIXFormatReader,
+)
+from py_arg.abstract_argumentation.import_export.argumentation_framework_from_iccma23_format_reader import (
+    ArgumentationFrameworkFromICCMA23FormatReader,
+)
+from py_arg.abstract_argumentation.import_export.argumentation_framework_from_json_reader import (
+    ArgumentationFrameworkFromJsonReader,
+)
+from py_arg.abstract_argumentation.import_export.argumentation_framework_from_trivial_graph_format_reader import (
+    ArgumentationFrameworkFromTrivialGraphFormatReader,
+)
+from py_arg.abstract_argumentation.import_export.argumentation_framework_to_aspartix_format_writer import (
+    ArgumentationFrameworkToASPARTIXFormatWriter,
+)
+from py_arg.abstract_argumentation.import_export.argumentation_framework_to_iccma23_format_writer import (
+    ArgumentationFrameworkToICCMA23FormatWriter,
+)
+from py_arg.abstract_argumentation.import_export.argumentation_framework_to_json_writer import (
+    ArgumentationFrameworkToJSONWriter,
+)
+from py_arg.abstract_argumentation.import_export.argumentation_framework_to_trivial_graph_format_writer import (
+    ArgumentationFrameworkToTrivialGraphFormatWriter,
+)
+from py_arg_visualisation.functions.explanations_functions.explanation_function_options import (
+    EXPLANATION_FUNCTION_OPTIONS,
+)
+from py_arg_visualisation.functions.explanations_functions.get_af_explanations import (
+    get_argumentation_framework_explanations,
+)
+from py_arg.abstract_argumentation.semantics.get_accepted_arguments import (
+    get_accepted_arguments,
+)
+from py_arg.abstract_argumentation.semantics.get_argumentation_framework_extensions import (
+    get_argumentation_framework_extensions,
+)
+from py_arg_visualisation.functions.extensions_functions.get_acceptance_strategy import (
+    get_acceptance_strategy,
+)
+from py_arg_visualisation.functions.graph_data_functions.get_af_dot_string import (
+    generate_plain_dot_string,
+    generate_dot_string,
+)
+from py_arg_visualisation.functions.graph_data_functions.get_af_graph_data import (
+    get_argumentation_framework_graph_data,
+)
+from py_arg_visualisation.functions.import_functions.read_argumentation_framework_functions import (
+    read_argumentation_framework,
+)
 
-dash.register_page(__name__, name='Visualise AF', title='Visualise AF')
+dash.register_page(__name__, name="Visualise AF", title="Visualise AF")
 
 
 # Create layout elements and compose them into the layout for this page.
 
+
 def get_abstract_setting_specification_div():
-    return html.Div(children=[
-        dcc.Store(id='selected-argument-store-abstract'),
-        dbc.Col([
-            dbc.Row([dbc.Col(dbc.Button(
-                'Generate random',
-                id='generate-random-af-button', n_clicks=0,
-                className='w-100')),
-                     dbc.Col(dcc.Upload(dbc.Button(
-                         'Open existing AF', className='w-100'),
-                         id='upload-af'))
-                     ], className='mt-2'),
-            dbc.Row([
-                dbc.Col([
-                    html.B('Arguments'),
-                    dbc.Textarea(
-                        id='abstract-arguments',
-                        placeholder='Add one argument per line. '
-                                    'For example:\n A\n B\n C',
-                        value='', style={'height': '300px'})
-                ]),
-                dbc.Col([
-                    html.B('Attacks'),
-                    dbc.Textarea(
-                        id='abstract-attacks',
-                        placeholder='Add one attack per line. '
-                                    'For example: \n (A,B) \n (A,C) \n (C,B)',
-                        value='', style={'height': '300px'}),
-                ])
-            ], className='mt-2'),
-            dbc.Row([
-                dbc.InputGroup([
-                    dbc.InputGroupText('Filename'),
-                    dbc.Input(value='edited_af', id='21-af-filename'),
-                    dbc.InputGroupText('.'),
-                    dbc.Select(
-                        options=[{'label': extension, 'value': extension}
-                                 for extension in ['JSON', 'TGF', 'APX',
-                                                   'ICCMA23']],
-                        value='JSON', id='21-af-extension'),
-                    dbc.Button('Download', id='21-af-download-button'),
-                ], className='mt-2'),
-                dcc.Download(id='21-af-download')
-            ])
-        ])
-    ])
+    return html.Div(
+        children=[
+            dcc.Store(id="selected-argument-store-abstract"),
+            dbc.Col(
+                [
+                    dbc.Row(
+                        [
+                            dbc.Col(
+                                dbc.Button(
+                                    "Generate random",
+                                    id="generate-random-af-button",
+                                    n_clicks=0,
+                                    className="w-100",
+                                )
+                            ),
+                            dbc.Col(
+                                dcc.Upload(
+                                    dbc.Button("Open existing AF", className="w-100"),
+                                    id="upload-af",
+                                )
+                            ),
+                        ],
+                        className="mt-2",
+                    ),
+                    dbc.Row(
+                        [
+                            dbc.Col(
+                                [
+                                    html.B("Arguments"),
+                                    dbc.Textarea(
+                                        id="abstract-arguments",
+                                        placeholder="Add one argument per line. "
+                                        "For example:\n A\n B\n C",
+                                        value="",
+                                        style={"height": "300px"},
+                                    ),
+                                ]
+                            ),
+                            dbc.Col(
+                                [
+                                    html.B("Attacks"),
+                                    dbc.Textarea(
+                                        id="abstract-attacks",
+                                        placeholder="Add one attack per line. "
+                                        "For example: \n (A,B) \n (A,C) \n (C,B)",
+                                        value="",
+                                        style={"height": "300px"},
+                                    ),
+                                ]
+                            ),
+                        ],
+                        className="mt-2",
+                    ),
+                    dbc.Row(
+                        [
+                            dbc.InputGroup(
+                                [
+                                    dbc.InputGroupText("Filename"),
+                                    dbc.Input(value="edited_af", id="21-af-filename"),
+                                    dbc.InputGroupText("."),
+                                    dbc.Select(
+                                        options=[
+                                            {"label": extension, "value": extension}
+                                            for extension in [
+                                                "JSON",
+                                                "TGF",
+                                                "APX",
+                                                "ICCMA23",
+                                            ]
+                                        ],
+                                        value="JSON",
+                                        id="21-af-extension",
+                                    ),
+                                    dbc.Button("Download", id="21-af-download-button"),
+                                ],
+                                className="mt-2",
+                            ),
+                            dcc.Download(id="21-af-download"),
+                        ]
+                    ),
+                ]
+            ),
+        ]
+    )
 
 
 def get_abstract_evaluation_div():
-    return html.Div([
-        html.Div([
-            dbc.Row([
-                dbc.Col(html.B('Semantics')),
-                dbc.Col(dbc.Select(options=[
-                    {'label': 'Admissible', 'value': 'Admissible'},
-                    {'label': 'Complete', 'value': 'Complete'},
-                    {'label': 'Grounded', 'value': 'Grounded'},
-                    {'label': 'Preferred', 'value': 'Preferred'},
-                    {'label': 'Ideal', 'value': 'Ideal'},
-                    {'label': 'Stable', 'value': 'Stable'},
-                    {'label': 'Semi-stable', 'value': 'SemiStable'},
-                    {'label': 'Eager', 'value': 'Eager'},
-                    {'label': 'Conflict-free', 'value': 'ConflictFree'},
-                    {'label': 'Naive', 'value': 'Naive'}
-                ], value='Complete', id='abstract-evaluation-semantics')),
-            ]),
-
-            dbc.Row([
-                dbc.Col(html.B('Evaluation strategy')),
-                dbc.Col(dbc.Select(
-                    options=[
-                        {'label': 'Credulous', 'value': 'Credulous'},
-                        {'label': 'Skeptical', 'value': 'Skeptical'}
-                    ], value='Credulous', id='abstract-evaluation-strategy')),
-            ]),
-            dbc.Row(id='abstract-evaluation')
-        ]),
-    ])
+    return html.Div(
+        [
+            html.Div(
+                [
+                    dbc.Row(
+                        [
+                            dbc.Col(html.B("Semantics")),
+                            dbc.Col(
+                                dbc.Select(
+                                    options=[
+                                        {"label": "Admissible", "value": "Admissible"},
+                                        {"label": "Complete", "value": "Complete"},
+                                        {"label": "Grounded", "value": "Grounded"},
+                                        {"label": "Preferred", "value": "Preferred"},
+                                        {"label": "Ideal", "value": "Ideal"},
+                                        {"label": "Stable", "value": "Stable"},
+                                        {"label": "Semi-stable", "value": "SemiStable"},
+                                        {"label": "Eager", "value": "Eager"},
+                                        {
+                                            "label": "Conflict-free",
+                                            "value": "ConflictFree",
+                                        },
+                                        {"label": "Naive", "value": "Naive"},
+                                    ],
+                                    value="Complete",
+                                    id="abstract-evaluation-semantics",
+                                )
+                            ),
+                        ]
+                    ),
+                    dbc.Row(
+                        [
+                            dbc.Col(html.B("Evaluation strategy")),
+                            dbc.Col(
+                                dbc.Select(
+                                    options=[
+                                        {"label": "Credulous", "value": "Credulous"},
+                                        {"label": "Skeptical", "value": "Skeptical"},
+                                    ],
+                                    value="Credulous",
+                                    id="abstract-evaluation-strategy",
+                                )
+                            ),
+                        ]
+                    ),
+                    dbc.Row(id="abstract-evaluation"),
+                ]
+            ),
+        ]
+    )
 
 
 def get_abstract_explanation_div():
-    return html.Div([
-        dbc.Row([
-            dbc.Col(html.B('Type')),
-            dbc.Col(dbc.Select(
-                options=[{'label': 'Acceptance', 'value': 'Acceptance'},
-                         {'label': 'Non-Acceptance',
-                          'value': 'NonAcceptance'}],
-                value='Acceptance', id='abstract-explanation-type'))]),
-        dbc.Row([
-            dbc.Col(html.B('Explanation function')),
-            dbc.Col(dbc.Select(id='abstract-explanation-function'))
-        ]),
-        dbc.Row(id='abstract-explanation')
-    ])
+    return html.Div(
+        [
+            dbc.Row(
+                [
+                    dbc.Col(html.B("Type")),
+                    dbc.Col(
+                        dbc.Select(
+                            options=[
+                                {"label": "Acceptance", "value": "Acceptance"},
+                                {"label": "Non-Acceptance", "value": "NonAcceptance"},
+                            ],
+                            value="Acceptance",
+                            id="abstract-explanation-type",
+                        )
+                    ),
+                ]
+            ),
+            dbc.Row(
+                [
+                    dbc.Col(html.B("Explanation function")),
+                    dbc.Col(dbc.Select(id="abstract-explanation-function")),
+                ]
+            ),
+            dbc.Row(id="abstract-explanation"),
+        ]
+    )
 
 
 left_column = dbc.Col(
-    dbc.Accordion([
-        dbc.AccordionItem(get_abstract_setting_specification_div(),
-                          title='Abstract Argumentation Framework'),
-        dbc.AccordionItem(get_abstract_evaluation_div(),
-                          title='Evaluation', item_id='Evaluation'),
-        dbc.AccordionItem(get_abstract_explanation_div(),
-                          title='Explanation', item_id='Explanation')
-    ], id='abstract-evaluation-accordion')
+    dbc.Accordion(
+        [
+            dbc.AccordionItem(
+                get_abstract_setting_specification_div(),
+                title="Abstract Argumentation Framework",
+                item_id="Plain_AF",
+            ),
+            dbc.AccordionItem(
+                get_abstract_evaluation_div(), title="Evaluation", item_id="Evaluation"
+            ),
+            dbc.AccordionItem(
+                get_abstract_explanation_div(),
+                title="Explanation",
+                item_id="Explanation",
+            ),
+        ],
+        id="abstract-evaluation-accordion",
+    )
 )
 
-right_column = dbc.Col([
-        dbc.Row([
-            dbc.Card(
-                dcc.Tabs([
-                    dcc.Tab(label='Default visualisation', children=[
-                        visdcc.Network(data={'nodes': [], 'edges': []},
-                                       id='abstract-argumentation-graph',
-                                       options={'height': '500px'})]),
-                    dcc.Tab(label='Layered visualisation', children=[
-                        html.Div([
-                            dash_interactive_graphviz.DashInteractiveGraphviz(
-                                id='explanation-graph',
-                                style={'height': '500px'}
+right_column = dbc.Col(
+    [
+        dbc.Row(
+            [
+                dbc.Card(
+                    dcc.Tabs(
+                        [
+                            dcc.Tab(
+                                label="Default visualisation",
+                                children=[
+                                    visdcc.Network(
+                                        data={"nodes": [], "edges": []},
+                                        id="abstract-argumentation-graph",
+                                        options={"height": "500px"},
+                                    )
+                                ],
                             ),
-                            html.Label('Layout:', style={'margin-top': '50px', 'display': 'inline-block'}),
-                            dcc.Dropdown(
-                                placeholder="Layout",
-                                options=['LR', 'RL', 'BT', 'TB'],
-                                value='BT',
-                                id='21-abstract-graph-layout',
-                                clearable=False,
-                                style={'width': '80px', 'position': 'absolute', 'top': '50px', 'left': '33px'}
-                            )
-                            ], style={'height': '500px'})
-                    ]),
-                ]))])])
+                            dcc.Tab(
+                                label="Layered visualisation",
+                                children=[
+                                    html.Div(
+                                        [
+                                            dash_interactive_graphviz.DashInteractiveGraphviz(
+                                                id="explanation-graph",
+                                                style={"height": "500px"},
+                                            ),
+                                            html.Label(
+                                                "Layout:",
+                                                style={
+                                                    "margin-top": "50px",
+                                                    "display": "inline-block",
+                                                },
+                                            ),
+                                            dcc.Dropdown(
+                                                placeholder="Layout",
+                                                options=["LR", "RL", "BT", "TB"],
+                                                value="BT",
+                                                id="21-abstract-graph-layout",
+                                                clearable=False,
+                                                style={
+                                                    "width": "80px",
+                                                    "position": "absolute",
+                                                    "top": "50px",
+                                                    "left": "33px",
+                                                },
+                                            ),
+                                        ],
+                                        style={"height": "500px"},
+                                    )
+                                ],
+                            ),
+                        ]
+                    )
+                )
+            ]
+        )
+    ]
+)
 
 layout_abstract = dbc.Row([left_column, right_column])
-layout = html.Div([html.H1(
-    'Visualisation of abstract argumentation frameworks'), layout_abstract])
+layout = html.Div(
+    [html.H1("Visualisation of abstract argumentation frameworks"), layout_abstract]
+)
 
 
 @callback(
-    Output('abstract-arguments', 'value'),
-    Output('abstract-attacks', 'value'),
-    Input('generate-random-af-button', 'n_clicks'),
-    Input('upload-af', 'contents'),
-    State('upload-af', 'filename'),
+    Output("abstract-arguments", "value"),
+    Output("abstract-attacks", "value"),
+    Input("generate-random-af-button", "n_clicks"),
+    Input("upload-af", "contents"),
+    State("upload-af", "filename"),
 )
 def generate_abstract_argumentation_framework(
-        _nr_of_clicks_random: int, af_content: str, af_filename: str):
+    _nr_of_clicks_random: int, af_content: str, af_filename: str
+):
     """
     Generate a random AF after clicking the button and put the result in the
     text box.
     """
-    if dash.callback_context.triggered_id == 'generate-random-af-button':
-        random_af = \
-            AbstractArgumentationFrameworkGenerator(8, 8, True).generate()
-        abstract_arguments_value = '\n'.join((str(arg)
-                                              for arg in random_af.arguments))
-        abstract_attacks_value = '\n'.join((f'({str(defeat.from_argument)},'
-                                            f'{str(defeat.to_argument)})'
-                                            for defeat in random_af.defeats))
+    if dash.callback_context.triggered_id == "generate-random-af-button":
+        random_af = AbstractArgumentationFrameworkGenerator(8, 8, True).generate()
+        abstract_arguments_value = "\n".join((str(arg) for arg in random_af.arguments))
+        abstract_attacks_value = "\n".join(
+            (
+                f"({str(defeat.from_argument)}," f"{str(defeat.to_argument)})"
+                for defeat in random_af.defeats
+            )
+        )
         return abstract_arguments_value, abstract_attacks_value
-    elif dash.callback_context.triggered_id == 'upload-af':
-        content_type, content_str = af_content.split(',')
+    elif dash.callback_context.triggered_id == "upload-af":
+        content_type, content_str = af_content.split(",")
         decoded = base64.b64decode(content_str)
 
-        name = af_filename.split('.')[0]
-        if af_filename.upper().endswith('.JSON'):
+        name = af_filename.split(".")[0]
+        if af_filename.upper().endswith(".JSON"):
             opened_af = ArgumentationFrameworkFromJsonReader().from_json(
-                json.loads(decoded))
-        elif af_filename.upper().endswith('.TGF'):
-            opened_af = ArgumentationFrameworkFromTrivialGraphFormatReader.\
-                from_tgf(decoded.decode(), name)
-        elif af_filename.upper().endswith('.APX'):
-            opened_af = ArgumentationFrameworkFromASPARTIXFormatReader.\
-                from_apx(decoded.decode(), name)
-        elif af_filename.upper().endswith('.ICCMA23'):
-            opened_af = ArgumentationFrameworkFromICCMA23FormatReader.\
-                from_iccma23(decoded.decode(), name)
+                json.loads(decoded)
+            )
+        elif af_filename.upper().endswith(".TGF"):
+            opened_af = ArgumentationFrameworkFromTrivialGraphFormatReader.from_tgf(
+                decoded.decode(), name
+            )
+        elif af_filename.upper().endswith(".APX"):
+            opened_af = ArgumentationFrameworkFromASPARTIXFormatReader.from_apx(
+                decoded.decode(), name
+            )
+        elif af_filename.upper().endswith(".ICCMA23"):
+            opened_af = ArgumentationFrameworkFromICCMA23FormatReader.from_iccma23(
+                decoded.decode(), name
+            )
         else:
-            raise NotImplementedError('This file format is currently not '
-                                      'supported.')
+            raise NotImplementedError("This file format is currently not " "supported.")
 
-        abstract_arguments_value = '\n'.join((str(arg)
-                                              for arg in opened_af.arguments))
-        abstract_attacks_value = '\n'.join((f'({str(defeat.from_argument)},'
-                                            f'{str(defeat.to_argument)})'
-                                            for defeat in opened_af.defeats))
+        abstract_arguments_value = "\n".join((str(arg) for arg in opened_af.arguments))
+        abstract_attacks_value = "\n".join(
+            (
+                f"({str(defeat.from_argument)}," f"{str(defeat.to_argument)})"
+                for defeat in opened_af.defeats
+            )
+        )
         return abstract_arguments_value, abstract_attacks_value
-    return '', ''
+    return "", ""
 
 
 @callback(
-    Output('abstract-argumentation-graph', 'data'),
-    Output('explanation-graph', 'dot_source'),
-    Input('abstract-arguments', 'value'),
-    Input('abstract-attacks', 'value'),
-    Input('selected-argument-store-abstract', 'data'),
-    Input('color-blind-mode', 'on'),
-    Input('21-abstract-graph-layout', 'value'),
-    prevent_initial_call=True
+    Output("abstract-argumentation-graph", "data"),
+    Output("explanation-graph", "dot_source"),
+    Input("abstract-arguments", "value"),
+    Input("abstract-attacks", "value"),
+    Input("selected-argument-store-abstract", "data"),
+    Input("color-blind-mode", "on"),
+    Input("21-abstract-graph-layout", "value"),
+    Input("abstract-evaluation-accordion", "active_item"),
+    State("selected-argument-store-abstract", "data"),
+    prevent_initial_call=True,
 )
 def create_abstract_argumentation_framework(
-        arguments: str, attacks: str, selected_arguments: Dict[str, List[str]],
-        color_blind_mode: bool, layout: str):
-    print(layout)
+    arguments: str,
+    attacks: str,
+    selected_arguments: Dict[str, List[str]],
+    color_blind_mode: bool,
+    dot_layout: str,
+    active_item: str,
+    stored_selected_arguments: Dict[str, List[str]],
+):
     """
     Send the AF data to the graph for plotting.
     """
@@ -278,205 +414,258 @@ def create_abstract_argumentation_framework(
     except ValueError:
         arg_framework = AbstractArgumentationFramework()
 
-    if dash.callback_context.triggered_id != \
-            'selected-argument-store-abstract':
+    if dash.callback_context.triggered_id != "selected-argument-store-abstract":
         selected_arguments = None
 
     data = get_argumentation_framework_graph_data(
-        arg_framework, selected_arguments, color_blind_mode)
+        arg_framework, selected_arguments, color_blind_mode
+    )
 
-    if not selected_arguments:
-        dot_source = generate_plain_dot_string(arg_framework, layout)
+    if active_item == "Plain_AF" or not stored_selected_arguments:
+        dot_source = generate_plain_dot_string(arg_framework, dot_layout)
     else:
+        selected_arguments = (
+            stored_selected_arguments
+            if selected_arguments is None and active_item != "Plain_AF"
+            else selected_arguments
+        )
         dot_source = generate_dot_string(
-            arg_framework, selected_arguments, color_blind_mode,layout)
+            arg_framework, selected_arguments, color_blind_mode, dot_layout
+        )
+
     return data, dot_source
 
 
 @callback(
-    Output('21-af-download', 'data'),
-    Input('21-af-download-button', 'n_clicks'),
-    State('abstract-arguments', 'value'),
-    State('abstract-attacks', 'value'),
-    State('21-af-filename', 'value'),
-    State('21-af-extension', 'value'),
+    Output("21-af-download", "data"),
+    Input("21-af-download-button", "n_clicks"),
+    State("abstract-arguments", "value"),
+    State("abstract-attacks", "value"),
+    State("21-af-filename", "value"),
+    State("21-af-extension", "value"),
     prevent_initial_call=True,
 )
 def download_generated_abstract_argumentation_framework(
-        _nr_clicks: int, arguments_text: str, defeats_text: str, filename: str,
-        extension: str):
-    argumentation_framework = read_argumentation_framework(arguments_text,
-                                                           defeats_text)
+    _nr_clicks: int,
+    arguments_text: str,
+    defeats_text: str,
+    filename: str,
+    extension: str,
+):
+    argumentation_framework = read_argumentation_framework(arguments_text, defeats_text)
 
-    if extension == 'JSON':
-        argumentation_framework_json = \
-            ArgumentationFrameworkToJSONWriter().to_dict(
-                argumentation_framework)
+    if extension == "JSON":
+        argumentation_framework_json = ArgumentationFrameworkToJSONWriter().to_dict(
+            argumentation_framework
+        )
         argumentation_framework_str = json.dumps(argumentation_framework_json)
-    elif extension == 'TGF':
-        argumentation_framework_str = \
+    elif extension == "TGF":
+        argumentation_framework_str = (
             ArgumentationFrameworkToTrivialGraphFormatWriter.write_to_str(
-                argumentation_framework)
-    elif extension == 'APX':
-        argumentation_framework_str = \
+                argumentation_framework
+            )
+        )
+    elif extension == "APX":
+        argumentation_framework_str = (
             ArgumentationFrameworkToASPARTIXFormatWriter.write_to_str(
-                argumentation_framework)
-    elif extension == 'ICCMA23':
-        argumentation_framework_str = \
+                argumentation_framework
+            )
+        )
+    elif extension == "ICCMA23":
+        argumentation_framework_str = (
             ArgumentationFrameworkToICCMA23FormatWriter.write_to_str(
-                argumentation_framework)
+                argumentation_framework
+            )
+        )
     else:
         raise NotImplementedError
 
-    return {'content': argumentation_framework_str,
-            'filename': filename + '.' + extension}
+    return {
+        "content": argumentation_framework_str,
+        "filename": filename + "." + extension,
+    }
 
 
 @callback(
-    Output('abstract-evaluation', 'children'),
-    State('abstract-arguments', 'value'),
-    State('abstract-attacks', 'value'),
-    Input('abstract-evaluation-accordion', 'active_item'),
-    Input('abstract-evaluation-semantics', 'value'),
-    Input('abstract-evaluation-strategy', 'value'),
-    prevent_initial_call=True
+    Output("abstract-evaluation", "children"),
+    State("abstract-arguments", "value"),
+    State("abstract-attacks", "value"),
+    Input("abstract-evaluation-accordion", "active_item"),
+    Input("abstract-evaluation-semantics", "value"),
+    Input("abstract-evaluation-strategy", "value"),
+    prevent_initial_call=True,
 )
-def evaluate_abstract_argumentation_framework(arguments: str, attacks: str,
-                                              active_item: str,
-                                              semantics: str, strategy: str):
-    if active_item != 'Evaluation':
+def evaluate_abstract_argumentation_framework(
+    arguments: str, attacks: str, active_item: str, semantics: str, strategy: str
+):
+    if active_item != "Evaluation":
         raise PreventUpdate
 
     # Read the abstract argumentation framework.
     arg_framework = read_argumentation_framework(arguments, attacks)
 
     # Compute the extensions and put them in a list of sets.
-    frozen_extensions = get_argumentation_framework_extensions(arg_framework,
-                                                               semantics)
-    extensions = [set(frozen_extension)
-                  for frozen_extension in frozen_extensions]
+    frozen_extensions = get_argumentation_framework_extensions(arg_framework, semantics)
+    extensions = [set(frozen_extension) for frozen_extension in frozen_extensions]
 
     # Make a button for each extension.
     extension_buttons = []
     for extension in sorted(extensions):
-        out_arguments = {attacked for attacked in arg_framework.arguments
-                         if any(argument in arg_framework.
-                                get_incoming_defeat_arguments(attacked)
-                                for argument in extension)}
-        undecided_arguments = {argument for argument in arg_framework.arguments
-                               if argument not in extension and
-                               argument not in out_arguments}
-        extension_readable_str = \
-            '{' + ', '.join(argument.name
-                            for argument in sorted(extension)) + '}'
-        extension_in_str = \
-            '+'.join(argument.name for argument in sorted(extension))
-        extension_out_str = \
-            '+'.join(argument.name for argument in sorted(out_arguments))
-        extension_undecided_str = \
-            '+'.join(argument.name for argument in sorted(undecided_arguments))
-        extension_long_str = \
-            '|'.join([extension_in_str, extension_undecided_str,
-                      extension_out_str])
+        out_arguments = {
+            attacked
+            for attacked in arg_framework.arguments
+            if any(
+                argument in arg_framework.get_incoming_defeat_arguments(attacked)
+                for argument in extension
+            )
+        }
+        undecided_arguments = {
+            argument
+            for argument in arg_framework.arguments
+            if argument not in extension and argument not in out_arguments
+        }
+        extension_readable_str = (
+            "{" + ", ".join(argument.name for argument in sorted(extension)) + "}"
+        )
+        extension_in_str = "+".join(argument.name for argument in sorted(extension))
+        extension_out_str = "+".join(
+            argument.name for argument in sorted(out_arguments)
+        )
+        extension_undecided_str = "+".join(
+            argument.name for argument in sorted(undecided_arguments)
+        )
+        extension_long_str = "|".join(
+            [extension_in_str, extension_undecided_str, extension_out_str]
+        )
         extension_buttons.append(
-            dbc.Button([extension_readable_str], color='secondary',
-                       id={'type': 'extension-button-abstract',
-                           'index': extension_long_str}))
+            dbc.Button(
+                [extension_readable_str],
+                color="secondary",
+                id={"type": "extension-button-abstract", "index": extension_long_str},
+            )
+        )
 
     # Based on the extensions, get the acceptance status of arguments.
     acceptance_strategy = get_acceptance_strategy(strategy)
-    accepted_arguments = get_accepted_arguments(
-        frozen_extensions, acceptance_strategy)
+    accepted_arguments = get_accepted_arguments(frozen_extensions, acceptance_strategy)
 
     # Make a button for each accepted argument.
     accepted_argument_buttons = [
-        dbc.Button(argument.name, color='secondary',
-                   id={'type': 'argument-button-abstract',
-                       'index': argument.name})
-        for argument in sorted(accepted_arguments)]
+        dbc.Button(
+            argument.name,
+            color="secondary",
+            id={"type": "argument-button-abstract", "index": argument.name},
+        )
+        for argument in sorted(accepted_arguments)
+    ]
 
-    return html.Div([html.B('The extension(s):'), html.Div(extension_buttons),
-                     html.B('The accepted argument(s):'),
-                     html.Div(accepted_argument_buttons),
-                     html.P('Click on the extension/argument buttons to '
-                            'display the corresponding argument(s) '
-                            'in the graph.')])
+    return html.Div(
+        [
+            html.B("The extension(s):"),
+            html.Div(extension_buttons),
+            html.B("The accepted argument(s):"),
+            html.Div(accepted_argument_buttons),
+            html.P(
+                "Click on the extension/argument buttons to "
+                "display the corresponding argument(s) "
+                "in the graph."
+            ),
+        ]
+    )
 
 
 @callback(
-    Output('selected-argument-store-abstract', 'data'),
-    Input({'type': 'extension-button-abstract', 'index': ALL}, 'n_clicks'),
-    Input({'type': 'argument-button-abstract', 'index': ALL}, 'n_clicks'),
-    State('selected-argument-store-abstract', 'data'),
+    Output("selected-argument-store-abstract", "data"),
+    Input({"type": "extension-button-abstract", "index": ALL}, "n_clicks"),
+    Input({"type": "argument-button-abstract", "index": ALL}, "n_clicks"),
+    State("selected-argument-store-abstract", "data"),
 )
-def mark_extension_or_argument_in_graph(_nr_of_clicks_extension_values,
-                                        _nr_of_clicks_argument_values,
-                                        old_selected_data: List[str]):
-    button_clicked_id = \
-        dash.callback_context.triggered[0]['prop_id'].split('.')[0]
-    if button_clicked_id == '':
+def mark_extension_or_argument_in_graph(
+    _nr_of_clicks_extension_values,
+    _nr_of_clicks_argument_values,
+    old_selected_data: List[str],
+):
+    button_clicked_id = dash.callback_context.triggered[0]["prop_id"].split(".")[0]
+    if button_clicked_id == "":
         return old_selected_data
     button_clicked_id_content = json.loads(button_clicked_id)
-    button_clicked_id_type = button_clicked_id_content['type']
-    button_clicked_id_index = button_clicked_id_content['index']
-    if button_clicked_id_type == 'extension-button-abstract':
-        in_part, undecided_part, out_part = \
-            button_clicked_id_index.split('|', 3)
-        return {'green': in_part.split('+'),
-                'yellow': undecided_part.split('+'),
-                'red': out_part.split('+')}
-    elif button_clicked_id_type == 'argument-button-abstract':
-        return {'blue': [button_clicked_id_index]}
+    button_clicked_id_type = button_clicked_id_content["type"]
+    button_clicked_id_index = button_clicked_id_content["index"]
+    if button_clicked_id_type == "extension-button-abstract":
+        in_part, undecided_part, out_part = button_clicked_id_index.split("|", 3)
+        return {
+            "green": in_part.split("+"),
+            "yellow": undecided_part.split("+"),
+            "red": out_part.split("+"),
+        }
+    elif button_clicked_id_type == "argument-button-abstract":
+        return {"blue": [button_clicked_id_index]}
     return []
 
 
 @callback(
-    Output('abstract-explanation-function', 'options'),
-    Output('abstract-explanation-function', 'value'),
-    [Input('abstract-explanation-type', 'value')]
+    Output("abstract-explanation-function", "options"),
+    Output("abstract-explanation-function", "value"),
+    [Input("abstract-explanation-type", "value")],
 )
 def setting_choice(choice: str):
-    return EXPLANATION_FUNCTION_OPTIONS[choice], \
-        EXPLANATION_FUNCTION_OPTIONS[choice][0]['value']
+    return EXPLANATION_FUNCTION_OPTIONS[choice], EXPLANATION_FUNCTION_OPTIONS[choice][
+        0
+    ]["value"]
 
 
 @callback(
-    Output('abstract-explanation', 'children'),
-    Input('abstract-evaluation-accordion', 'active_item'),
-    State('abstract-arguments', 'value'),
-    State('abstract-attacks', 'value'),
-    State('abstract-evaluation-semantics', 'value'),
-    Input('abstract-explanation-function', 'value'),
-    Input('abstract-explanation-type', 'value'),
-    State('abstract-evaluation-strategy', 'value'),
-    prevent_initial_call=True
+    Output("abstract-explanation", "children"),
+    Input("abstract-evaluation-accordion", "active_item"),
+    State("abstract-arguments", "value"),
+    State("abstract-attacks", "value"),
+    State("abstract-evaluation-semantics", "value"),
+    Input("abstract-explanation-function", "value"),
+    Input("abstract-explanation-type", "value"),
+    State("abstract-evaluation-strategy", "value"),
+    prevent_initial_call=True,
 )
 def derive_explanations_abstract_argumentation_framework(
-        active_item, arguments: str, attacks: str, semantics: str,
-        explanation_function: str, explanation_type: str,
-        explanation_strategy: str):
-    if active_item != 'Explanation':
+    active_item,
+    arguments: str,
+    attacks: str,
+    semantics: str,
+    explanation_function: str,
+    explanation_type: str,
+    explanation_strategy: str,
+):
+    if active_item != "Explanation":
         raise PreventUpdate
 
     # Compute the explanations based on the input.
     arg_framework = read_argumentation_framework(arguments, attacks)
-    frozen_extensions = get_argumentation_framework_extensions(arg_framework,
-                                                               semantics)
-    extensions = [set(frozen_extension)
-                  for frozen_extension in frozen_extensions]
+    frozen_extensions = get_argumentation_framework_extensions(arg_framework, semantics)
+    extensions = [set(frozen_extension) for frozen_extension in frozen_extensions]
     acceptance_strategy = get_acceptance_strategy(explanation_strategy)
-    accepted_arguments = get_accepted_arguments(
-        frozen_extensions, acceptance_strategy)
+    accepted_arguments = get_accepted_arguments(frozen_extensions, acceptance_strategy)
     explanations = get_argumentation_framework_explanations(
-        arg_framework, extensions, accepted_arguments,
-        explanation_function, explanation_type)
+        arg_framework,
+        extensions,
+        accepted_arguments,
+        explanation_function,
+        explanation_type,
+    )
 
     # Print the explanations for each of the arguments.
-    return html.Div([html.Div(html.B('Explanation(s) by argument:'))] +
-                    [html.Div([
-                        html.B(explanation_key),
-                        html.Ul([html.Li(str(explanation_value).replace(
-                            'set()', '{}'))
-                            for explanation_value in explanation_values])])
-                     for explanation_key, explanation_values in
-                        explanations.items()])
+    return html.Div(
+        [html.Div(html.B("Explanation(s) by argument:"))]
+        + [
+            html.Div(
+                [
+                    html.B(explanation_key),
+                    html.Ul(
+                        [
+                            html.Li(str(explanation_value).replace("set()", "{}"))
+                            for explanation_value in explanation_values
+                        ]
+                    ),
+                ]
+            )
+            for explanation_key, explanation_values in explanations.items()
+        ]
+    )


### PR DESCRIPTION
Fixed a few things based on Friday's meeting

- Add layout dropdown (now users can change the layout LR, RL, BT, TB for the Graphviz)
- Fix the edge numbers
- Change all dotted edges to dashed edges

Additionally, I fixed a few logistics set-up, when click `Abstract Argumentatuon Framework`, users will get only the `plain_graph`. By clicking `Evaluation`, users then can access the colored one.

**Discussion point**: As Bertram suggest we use Orange and Blue, I was wondering maybe we can change the red color in Colorblind mode as orange and blue to minimize the implementation

PS: it looks like the code have been auto-formatted by Ruff because of my VScode setting. Not sure if that's Ok for you